### PR TITLE
Add `.#format` app to flake output

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,5 @@ See [this PR](https://github.com/srid/haskell-template/pull/36) for a complete e
 ```
 
 This adds a `.#checks.<system>.treefmt` flake output that checks that the project tree is already autoformatted.
+
+It also adds a `.#apps.<system>.format` output that can can be used to format your project using `nix run .#format`.

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -34,6 +34,15 @@ in
   };
   config = {
     perSystem = { config, self', inputs', pkgs, ... }: {
+      apps.format = {
+        type = "app";
+        program = pkgs.writeShellApplication {
+          name = "format";
+          runtimeInputs = config.treefmt.buildInputs; 
+          text = "treefmt";
+        };
+      };
+
       checks.treefmt = pkgs.runCommandLocal "treefmt-check"
         {
           buildInputs = [ pkgs.git ] ++ config.treefmt.buildInputs;


### PR DESCRIPTION
Tested it with a local repository. usage: `nix run .#format`